### PR TITLE
Fix endlessly increasing memory consumption with the '-W' option

### DIFF
--- a/src/XKeyboard.cpp
+++ b/src/XKeyboard.cpp
@@ -119,6 +119,8 @@ void XKeyboard::build_layout_from(string_vector& out, const layout_variant_strin
   std::istringstream layout(lv.first);
   std::istringstream variant(lv.second);
 
+  out.clear();
+
   while(true) {
     string l,v;
 


### PR DESCRIPTION
`build_layout` **appends** the current layouts to the vector `syms`, without clearing them beforehand. With the `-W` option, this code path is executed everytime the layout changes. Therefore, this leads to a huge, unnecessary memory consumption.