### PR TITLE
Fix corrupting cerr stream

### DIFF
--- a/src/XKeyboard.cpp
+++ b/src/XKeyboard.cpp
@@ -108,7 +108,10 @@ layout_variant_strings XKeyboard::get_layout_variant()
   CHECK_MSG(_verbose, bret==True, "Failed to get keyboard properties");
 
   MSG(_verbose, "raw layout string \"" << vdr._it.layout << "\"");
-  MSG(_verbose, "raw variant string \"" << vdr._it.variant << "\"");
+  if(vdr._it.variant)
+    MSG(_verbose, "raw variant string \"" << vdr._it.variant << "\"");
+  else
+    MSG(_verbose, "No raw variant string");
 
   return make_pair(string(vdr._it.layout ? vdr._it.layout : "us"),
                    string(vdr._it.variant ? vdr._it.variant : ""));


### PR DESCRIPTION
On my machine `vdr._it.variant` is `NULL`. Therefore, `NULL` is sent to `std:cerr` which makes it [bad](https://www.cplusplus.com/reference/ios/ios/bad/). Consequently, the program continues to work but everything sent to cerr is ignored, leading to missing debug messages.